### PR TITLE
(feat) beautify raw json body request

### DIFF
--- a/webview/components/RequestOptionsBar/index.tsx
+++ b/webview/components/RequestOptionsBar/index.tsx
@@ -11,7 +11,7 @@ export const RequestOptionsTab = (props) => {
 
   return (
     <div className="request-options-tab-wrapper">
-      <div className="request-options">
+      <div className="request-options-left">
         {requestOptions.map((option) => (
           <button
             key={option.value}
@@ -37,14 +37,23 @@ export const RequestOptionsTab = (props) => {
           </button>
         ))}
       </div>
-      <button
-        id="request-code"
-        name="request-code"
-        className="button-request-code"
-        onClick={() => setSelected("code")}
-      >
-        Code
-      </button>
+      <div className="request-options-right">
+        <button
+          id="request-code"
+          name="request-code"
+          className="button-request"
+          onClick={() => setSelected("code")}
+        >
+          Code
+        </button>
+        <button
+          id="request-beautify"
+          name="request-beautify"
+          className="button-request"
+        >
+          Beautify
+        </button>
+      </div>
     </div>
   );
 };

--- a/webview/components/RequestOptionsBar/index.tsx
+++ b/webview/components/RequestOptionsBar/index.tsx
@@ -2,24 +2,16 @@ import * as React from "react";
 import "./styles.css";
 import * as propTypes from "prop-types";
 import { requestOptions } from "../../constants/request-options";
-import { useAppSelector, useAppDispatch } from "../../redux/hooks";
+import { useAppSelector } from "../../redux/hooks";
 import { selectRequestHeaders } from "../../features/requestHeader/requestHeaderSlice";
-import {
-  requestBodyRawFormatUpdated,
-  selectRequestBodyMode,
-  selectRequestBodyRawLanguage,
-} from "../../features/requestBody/requestBodySlice";
 
 export const RequestOptionsTab = (props) => {
   const { selected, setSelected } = props;
-  const dispatch = useAppDispatch();
   const header = useAppSelector(selectRequestHeaders);
-  const bodyMode = useAppSelector(selectRequestBodyMode);
-  const language = useAppSelector(selectRequestBodyRawLanguage);
-  const hideBeautifyButton = bodyMode === "raw" && language === "json";
+
   return (
     <div className="request-options-tab-wrapper">
-      <div className="request-options-left">
+      <div className="request-options">
         {requestOptions.map((option) => (
           <button
             key={option.value}
@@ -45,28 +37,14 @@ export const RequestOptionsTab = (props) => {
           </button>
         ))}
       </div>
-      <div className="request-options-right">
-        <button
-          id="request-code"
-          name="request-code"
-          className="button-request"
-          onClick={() => setSelected("code")}
-        >
-          Code
-        </button>
-        <button
-          id="request-beautify"
-          name="request-beautify"
-          className={
-            hideBeautifyButton ? "button-request" : "button-request hidden"
-          }
-          onClick={() => {
-            dispatch(requestBodyRawFormatUpdated(true));
-          }}
-        >
-          Beautify
-        </button>
-      </div>
+      <button
+        id="request-code"
+        name="request-code"
+        className="button-request"
+        onClick={() => setSelected("code")}
+      >
+        Code
+      </button>
     </div>
   );
 };

--- a/webview/components/RequestOptionsBar/index.tsx
+++ b/webview/components/RequestOptionsBar/index.tsx
@@ -4,11 +4,17 @@ import * as propTypes from "prop-types";
 import { requestOptions } from "../../constants/request-options";
 import { useAppSelector } from "../../redux/hooks";
 import { selectRequestHeaders } from "../../features/requestHeader/requestHeaderSlice";
+import {
+  selectRequestBodyMode,
+  selectRequestBodyRawLanguage,
+} from "../../features/requestBody/requestBodySlice";
 
 export const RequestOptionsTab = (props) => {
   const { selected, setSelected } = props;
   const header = useAppSelector(selectRequestHeaders);
-
+  const body = useAppSelector(selectRequestBodyMode);
+  const language = useAppSelector(selectRequestBodyRawLanguage);
+  const hideBeautifyButton = body === "raw" && language === "json";
   return (
     <div className="request-options-tab-wrapper">
       <div className="request-options-left">
@@ -49,7 +55,9 @@ export const RequestOptionsTab = (props) => {
         <button
           id="request-beautify"
           name="request-beautify"
-          className="button-request"
+          className={
+            hideBeautifyButton ? "button-request" : "button-request hidden"
+          }
         >
           Beautify
         </button>

--- a/webview/components/RequestOptionsBar/index.tsx
+++ b/webview/components/RequestOptionsBar/index.tsx
@@ -2,19 +2,21 @@ import * as React from "react";
 import "./styles.css";
 import * as propTypes from "prop-types";
 import { requestOptions } from "../../constants/request-options";
-import { useAppSelector } from "../../redux/hooks";
+import { useAppSelector, useAppDispatch } from "../../redux/hooks";
 import { selectRequestHeaders } from "../../features/requestHeader/requestHeaderSlice";
 import {
+  requestBodyRawFormatUpdated,
   selectRequestBodyMode,
   selectRequestBodyRawLanguage,
 } from "../../features/requestBody/requestBodySlice";
 
 export const RequestOptionsTab = (props) => {
   const { selected, setSelected } = props;
+  const dispatch = useAppDispatch();
   const header = useAppSelector(selectRequestHeaders);
-  const body = useAppSelector(selectRequestBodyMode);
+  const bodyMode = useAppSelector(selectRequestBodyMode);
   const language = useAppSelector(selectRequestBodyRawLanguage);
-  const hideBeautifyButton = body === "raw" && language === "json";
+  const hideBeautifyButton = bodyMode === "raw" && language === "json";
   return (
     <div className="request-options-tab-wrapper">
       <div className="request-options-left">
@@ -58,6 +60,9 @@ export const RequestOptionsTab = (props) => {
           className={
             hideBeautifyButton ? "button-request" : "button-request hidden"
           }
+          onClick={() => {
+            dispatch(requestBodyRawFormatUpdated(true));
+          }}
         >
           Beautify
         </button>

--- a/webview/components/RequestOptionsBar/styles.css
+++ b/webview/components/RequestOptionsBar/styles.css
@@ -4,7 +4,7 @@
   padding: 15px 20px 0 20px;
 }
 
-.request-options-left, .request-options-right {
+.request-options {
   display: flex;
 }
 

--- a/webview/components/RequestOptionsBar/styles.css
+++ b/webview/components/RequestOptionsBar/styles.css
@@ -4,7 +4,7 @@
   padding: 15px 20px 0 20px;
 }
 
-.request-options {
+.request-options-left, .request-options-right {
   display: flex;
 }
 
@@ -35,7 +35,7 @@
   color: var(--tab-info);
 }
 
-.button-request-code {
+.button-request {
   display: inline-block;
   cursor: pointer;
   background-color: transparent;
@@ -46,6 +46,11 @@
   font-weight: 500;
   font-size: 12px;
 }
-.button-request-code:hover {
+
+.button-request:hover {
   color: var(--primary-dark);
+}
+
+.hidden {
+  display: none; 
 }

--- a/webview/features/requestBody/Raw/index.tsx
+++ b/webview/features/requestBody/Raw/index.tsx
@@ -4,6 +4,7 @@ import { useAppDispatch, useAppSelector } from "../../../redux/hooks";
 import {
   requestBodyRawUpdated,
   selectRequestBodyRaw,
+  selectRequestBodyRawFormat,
   selectRequestBodyRawLanguage,
 } from "../requestBodySlice";
 
@@ -12,6 +13,7 @@ const Editor = React.lazy(() => import("../../../shared/Editor"));
 export const Raw = () => {
   const raw = useAppSelector(selectRequestBodyRaw);
   const language = useAppSelector(selectRequestBodyRawLanguage);
+  const format = useAppSelector(selectRequestBodyRawFormat);
   const dispatch = useAppDispatch();
 
   return (
@@ -21,6 +23,7 @@ export const Raw = () => {
           className="raw-editor"
           value={raw}
           language={language}
+          format={format}
           onChange={(data) => dispatch(requestBodyRawUpdated(data))}
         />
       </React.Suspense>

--- a/webview/features/requestBody/RequestBody/index.tsx
+++ b/webview/features/requestBody/RequestBody/index.tsx
@@ -12,6 +12,7 @@ import {
   requestBodyModeUpdated,
   selectRequestBodyMode,
   selectRequestBodyRawLanguage,
+  requestBodyRawFormatUpdated,
 } from "../requestBodySlice";
 import "./styles.css";
 import { useAppDispatch, useAppSelector } from "../../../redux/hooks";
@@ -19,6 +20,7 @@ import { useAppDispatch, useAppSelector } from "../../../redux/hooks";
 export const Body = () => {
   const bodyMode = useAppSelector(selectRequestBodyMode);
   const language = useAppSelector(selectRequestBodyRawLanguage);
+  const hideBeautifyButton = bodyMode === "raw" && language === "json";
   const dispatch = useAppDispatch();
 
   return (
@@ -57,6 +59,18 @@ export const Body = () => {
             ))}
           </select>
         ) : null}
+        <button
+          id="request-beautify"
+          name="request-beautify"
+          className={
+            hideBeautifyButton ? "button-request" : "button-request hidden"
+          }
+          onClick={() => {
+            dispatch(requestBodyRawFormatUpdated(true));
+          }}
+        >
+          Beautify
+        </button>
       </div>
       <div className="request-body-window-wrapper">
         {bodyMode === "none" ? (

--- a/webview/features/requestBody/RequestBody/styles.css
+++ b/webview/features/requestBody/RequestBody/styles.css
@@ -58,3 +58,7 @@
 .select-raw-lang:focus {
   outline: none;
 }
+
+#request-beautify {
+  margin-left: 10px;
+}

--- a/webview/features/requestBody/requestBodySlice.ts
+++ b/webview/features/requestBody/requestBodySlice.ts
@@ -28,10 +28,12 @@ export interface RequestBodyState {
   urlencoded: { key: string; value: string; description: string }[];
   options: any;
   graphql: { query: string; variables: string };
+  format: boolean;
 }
 
 const initialState: RequestBodyState = {
   disabled: true,
+  format: false,
   raw: "",
   file: "",
   fileData: "",
@@ -66,6 +68,9 @@ const requestBodySlice = createSlice({
     requestBodyRawUpdated(state, action: PayloadAction<string>) {
       state.raw = action.payload;
     },
+    requestBodyRawFormatUpdated(state, action: PayloadAction<boolean>) {
+      state.format = action.payload;
+    },
     requestBodyRawLanguageUpdated(state, action: PayloadAction<string>) {
       state.options.raw.language = action.payload;
     },
@@ -98,6 +103,7 @@ export const {
   requestBodyFormDataItemUpdated,
   requestBodyModeUpdated,
   requestBodyRawUpdated,
+  requestBodyRawFormatUpdated,
   requestBodyRawLanguageUpdated,
   requestBodyUrlEncodedItemAdded,
   requestBodyUrlEncodedItemDeleted,
@@ -124,5 +130,7 @@ export const selectRequestBodyGraphqlQuery = (state: RootState) =>
   state.requestBody.graphql.query;
 export const selectRequestBodyGraphqlVariables = (state: RootState) =>
   state.requestBody.graphql.variables;
+export const selectRequestBodyRawFormat = (state: RootState) =>
+  state.requestBody.format;
 
 export default requestBodySlice.reducer;

--- a/webview/shared/Editor/index.tsx
+++ b/webview/shared/Editor/index.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 import * as monaco from "monaco-editor";
 import * as propTypes from "prop-types";
 import "./styles.css";
+import { useAppDispatch } from "../../redux/hooks";
+import { requestBodyRawFormatUpdated } from "../../features/requestBody/requestBodySlice";
 
 const Editor = (props) => {
   const { value, language, onChange, readOnly, className, copyButton, format } =
@@ -10,6 +12,7 @@ const Editor = (props) => {
   const divEl = React.useRef<HTMLDivElement>(null);
   const [editor, setEditor] = React.useState(undefined);
   const [copy, setCopy] = React.useState("Copy");
+  const dispatch = useAppDispatch();
 
   React.useEffect(() => {
     if (divEl.current) {
@@ -56,6 +59,7 @@ const Editor = (props) => {
             .run()
             .then(() => {
               editor.updateOptions({ readOnly });
+              dispatch(requestBodyRawFormatUpdated(false));
             });
         }, 300);
       }


### PR DESCRIPTION
With the use of Monaco Editor, it isn't really clear from the UI how to format a raw JSON body request.

To overcome this, I have introduced a "beautify" button to format the raw request JSON. 

It will only appear in the event that the request body is "**raw**" and the language chosen is "**JSON**". This is an identical feature to what Postman has.

![beautify](https://user-images.githubusercontent.com/15982721/124643319-df683880-de88-11eb-8635-cda8ace0d4eb.gif)



