### PR TITLE
(feat) add request options strict ssl

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,8 @@
 import * as vscode from "vscode";
 import * as fs from "fs";
 import axios from "axios";
+import * as https from 'https';
+import { RequestOptions } from "../webview/features/requestOptions/requestOptionsSlice";
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -56,7 +58,7 @@ export function activate(context: vscode.ExtensionContext) {
       );
 
       panel.webview.onDidReceiveMessage(
-        ({ method, url, headers, body, auth }) => {
+        ({ method, url, headers, body, auth, options }) => {
           if (!url) {
             panel.webview.postMessage({
               type: "response",
@@ -115,6 +117,12 @@ export function activate(context: vscode.ExtensionContext) {
             });
             headersObj["Content-Type"] = "application/json";
           }
+
+          // Options Section
+          let requestOptions = options as RequestOptions;
+
+          // Option 1. StrictSSL
+          https.globalAgent.options.rejectUnauthorized = (requestOptions.strictSSL === "yes");
 
           axios({
             method,

--- a/webview/components/RequestBar/index.tsx
+++ b/webview/components/RequestBar/index.tsx
@@ -8,6 +8,7 @@ import { selectRequestBody } from "../../features/requestBody/requestBodySlice";
 import { selectRequestHeaders } from "../../features/requestHeader/requestHeaderSlice";
 import { selectRequestUrl } from "../../features/requestUrl/requestUrlSlice";
 import { selectRequestMethod } from "../../features/requestMethod/requestMethodSlice";
+import { selectRequestOptions } from "../../features/requestOptions/requestOptionsSlice";
 import { useAppDispatch, useAppSelector } from "../../redux/hooks";
 import "./styles.css";
 
@@ -19,6 +20,7 @@ export const RequestBar = () => {
   const requestBody = useAppSelector(selectRequestBody);
   const requestUrl = useAppSelector(selectRequestUrl);
   const requestAuth = useAppSelector(selectRequestAuth);
+  const requestOptions = useAppSelector(selectRequestOptions);
 
   return (
     <form
@@ -31,6 +33,7 @@ export const RequestBar = () => {
           body: requestBody,
           headers: requestHeaders,
           url: requestUrl,
+          options: requestOptions
         });
         e.preventDefault();
       }}

--- a/webview/components/RequestOptionsWindow/index.tsx
+++ b/webview/components/RequestOptionsWindow/index.tsx
@@ -4,6 +4,7 @@ import { RequestAuth } from "../../features/requestAuth/RequestAuth";
 import { Body } from "../../features/requestBody/RequestBody";
 import { Headers } from "../../features/requestHeader/HeadersWindow";
 import { CodeSnippet } from "../../features/codeGen/CodeSnippet";
+import { RequestOptions } from "../../features/requestOptions/RequestOptions";
 import * as propTypes from "prop-types";
 import "./styles.css";
 
@@ -21,6 +22,8 @@ export const RequestOptionsWindow = (props) => {
         <Headers />
       ) : selected === "code" ? (
         <CodeSnippet />
+      ) : selected === "options" ? (
+        <RequestOptions />
       ) : null}
     </div>
   );

--- a/webview/constants/request-options.ts
+++ b/webview/constants/request-options.ts
@@ -15,4 +15,8 @@ export const requestOptions = [
     name: "Body",
     value: "body",
   },
+  {
+    name: "Options",
+    value: "options",
+  },
 ];

--- a/webview/features/requestOptions/RequestOptions/index.tsx
+++ b/webview/features/requestOptions/RequestOptions/index.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { useDispatch } from 'react-redux';
+import { useAppSelector } from '../../../redux/hooks';
+import { requestOptionsUpdated, selectRequestOptions, requestOptionsList } from '../requestOptionsSlice';
+import "./styles.css";
+
+export const RequestOptions = () => {
+    const requestOptions = useAppSelector(selectRequestOptions)
+    const dispatch = useDispatch()
+
+    return (
+        <div className="req-options-wrapper">
+            <div className="options">
+                {
+                    requestOptionsList.map(({ name, value, type, ...optionDetails }) => (
+                        <React.Fragment key={`req-option-${value}`}>
+                            <div className="req-option-label">{`${name}: `}</div>
+                            {
+                                type === 'select' ? (
+                                    <select
+                                        onChange={(e) => dispatch(requestOptionsUpdated({
+                                            ...requestOptions,
+                                            strictSSL: e.target.value === "yes"
+                                        }))}
+                                        defaultValue={optionDetails.default}
+                                        className="req-option-switch"
+                                    >
+                                        {optionDetails.options.map(({ key, value }) => (
+                                            <option key={key} value={value} >{value}</option>
+                                        ))}
+                                    </select>
+                                ) : null
+                            }
+                        </React.Fragment>
+                    ))
+                }
+            </div>
+        </div>
+    )
+}

--- a/webview/features/requestOptions/RequestOptions/index.tsx
+++ b/webview/features/requestOptions/RequestOptions/index.tsx
@@ -20,7 +20,7 @@ export const RequestOptions = () => {
                                     <select
                                         onChange={(e) => dispatch(requestOptionsUpdated({
                                             ...requestOptions,
-                                            [value]: e.target.value === "yes"
+                                            [value]: e.target.value
                                         }))}
                                         defaultValue={optionDetails.default}
                                         className="req-option-switch"

--- a/webview/features/requestOptions/RequestOptions/index.tsx
+++ b/webview/features/requestOptions/RequestOptions/index.tsx
@@ -20,7 +20,7 @@ export const RequestOptions = () => {
                                     <select
                                         onChange={(e) => dispatch(requestOptionsUpdated({
                                             ...requestOptions,
-                                            strictSSL: e.target.value === "yes"
+                                            [value]: e.target.value === "yes"
                                         }))}
                                         defaultValue={optionDetails.default}
                                         className="req-option-switch"
@@ -30,6 +30,8 @@ export const RequestOptions = () => {
                                         ))}
                                     </select>
                                 ) : null
+                                // Note: Augment this switch later with different renderers for 
+                                // different types of options
                             }
                         </React.Fragment>
                     ))

--- a/webview/features/requestOptions/RequestOptions/styles.css
+++ b/webview/features/requestOptions/RequestOptions/styles.css
@@ -1,0 +1,27 @@
+.req-options-wrapper {
+    margin-top: 15px;
+}
+
+.options {
+    display: flex;
+    align-items: center;
+}
+
+.req-option-label {
+    font-size: var(--default-font-size);
+    color: var(--default-text);
+    padding-right: 12px;
+}
+
+.req-option-switch {
+    padding: 4px;
+    display: inline-block;
+    font-weight: 600;
+    outline: none;
+    border: var(--default-border-size) solid var(--border);
+    border-radius: 2px;
+    background-color: var(--background);
+    color: var(--default-text-light);
+    cursor: pointer;
+    font-size: var(--default-font-size);
+  }

--- a/webview/features/requestOptions/requestOptionsSlice.ts
+++ b/webview/features/requestOptions/requestOptionsSlice.ts
@@ -15,11 +15,11 @@ export const requestOptionsList = [
 ]
 
 export interface RequestOptions {
-    strictSSL: boolean
+    strictSSL: string
 }
 
 const initialState = {
-    strictSSL: true
+    strictSSL: "yes"
 };
 
 const requestOptionsSlice = createSlice({

--- a/webview/features/requestOptions/requestOptionsSlice.ts
+++ b/webview/features/requestOptions/requestOptionsSlice.ts
@@ -1,0 +1,39 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { RootState } from "../../redux/store";
+
+export const requestOptionsList = [
+    {
+        name: "Strict SSL",
+        value: "strictSSL",
+        type: 'select',
+        options: [
+            { key: "yes", value: "Yes" },
+            { key: "no", value: "No" }
+        ],
+        default: "Yes"
+    }
+]
+
+export interface RequestOptions {
+    strictSSL: boolean
+}
+
+const initialState = {
+    strictSSL: true
+};
+
+const requestOptionsSlice = createSlice({
+    name: "requestOptions",
+    initialState,
+    reducers: {
+        requestOptionsUpdated(_, action: PayloadAction<RequestOptions>) {
+            return action.payload;
+        },
+    },
+});
+
+export const { requestOptionsUpdated } = requestOptionsSlice.actions;
+
+export const selectRequestOptions = (state: RootState) => state.requestOptions;
+
+export default requestOptionsSlice.reducer;

--- a/webview/redux/store.ts
+++ b/webview/redux/store.ts
@@ -6,6 +6,7 @@ import requestMethodReducer from "../features/requestMethod/requestMethodSlice";
 import requestUrlReducer from "../features/requestUrl/requestUrlSlice";
 import responseReducer from "../features/response/responseSlice";
 import codeGenOptionsReducer from "../features/codeGen/codeGenSlice";
+import requestOptionsReducer from '../features/requestOptions/requestOptionsSlice';
 
 let preloadedState;
 if (typeof window !== "undefined") {
@@ -22,6 +23,7 @@ export const store = configureStore({
     requestUrl: requestUrlReducer,
     response: responseReducer,
     codeGenOptions: codeGenOptionsReducer,
+    requestOptions: requestOptionsReducer
   },
   preloadedState,
 });


### PR DESCRIPTION
closes #26 

## preview
![Screenshot from 2021-08-01 13-33-27](https://user-images.githubusercontent.com/9134050/127763974-77802d72-c61d-4dd8-9432-a0082f79e059.png)

## changes 
- added a 'StrictSSL' option in a new 'Options' tab

## ref
- this is the thread which had the fix - https://github.com/axios/axios/issues/535#issuecomment-599971219

## testing
- used a dotnet webapi - scaffolded with `dotnet new webapi -o sample.api`
- this has a `GET /weatherforecast` which uses https  (https://localhost:5001/weatherforecast)
- with strict SSL set to "Yes", the request fails with `Error: unable to verify first certificate`
- with strict SSL set to "No", the request works great!

Yay! :rocket: 


