### PR TITLE
(feature) display response time for successful requests 

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@
 import * as vscode from "vscode";
 import * as fs from "fs";
 import axios from "axios";
-import * as https from 'https';
+import * as https from "https";
 import { RequestOptions } from "../webview/features/requestOptions/requestOptionsSlice";
 
 // this method is called when your extension is activated
@@ -59,6 +59,9 @@ export function activate(context: vscode.ExtensionContext) {
 
       panel.webview.onDidReceiveMessage(
         ({ method, url, headers, body, auth, options }) => {
+          // Options Section
+          const requestOptions = options as RequestOptions;
+
           if (!url) {
             panel.webview.postMessage({
               type: "response",
@@ -118,11 +121,9 @@ export function activate(context: vscode.ExtensionContext) {
             headersObj["Content-Type"] = "application/json";
           }
 
-          // Options Section
-          let requestOptions = options as RequestOptions;
-
           // Option 1. StrictSSL
-          https.globalAgent.options.rejectUnauthorized = (requestOptions.strictSSL === "yes");
+          https.globalAgent.options.rejectUnauthorized =
+            requestOptions.strictSSL === "yes";
 
           axios({
             method,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,6 +61,7 @@ export function activate(context: vscode.ExtensionContext) {
         ({ method, url, headers, body, auth, options }) => {
           // Options Section
           const requestOptions = options as RequestOptions;
+          let requestStartedAt, responseDuration;
 
           if (!url) {
             panel.webview.postMessage({
@@ -125,6 +126,16 @@ export function activate(context: vscode.ExtensionContext) {
           https.globalAgent.options.rejectUnauthorized =
             requestOptions.strictSSL === "yes";
 
+          axios.interceptors.request.use((config) => {
+            requestStartedAt = new Date().getTime();
+            return config;
+          });
+
+          axios.interceptors.response.use((config) => {
+            responseDuration = new Date().getTime() - requestStartedAt;
+            return config;
+          });
+
           axios({
             method,
             url,
@@ -143,6 +154,7 @@ export function activate(context: vscode.ExtensionContext) {
                 status: resp.status,
                 statusText: resp.statusText,
                 headers: resp.headers,
+                duration: responseDuration,
               })
             )
             .catch((err) => {

--- a/webview/features/response/ResponseTab/index.tsx
+++ b/webview/features/response/ResponseTab/index.tsx
@@ -6,6 +6,15 @@ import { supportedLangs } from "../../../constants/supported-langs";
 import { useAppSelector } from "../../../redux/hooks";
 import { selectResponse } from "../responseSlice";
 
+const ResponseInfo = ({ responseTitle, info }) => {
+  return (
+    <>
+      <div>{responseTitle}</div>
+      <div className="text-response-info">{info}</div>
+    </>
+  );
+};
+
 export const ResponseTab = (props) => {
   const { selected, setSelected, language, setLanguage } = props;
   const response = useAppSelector(selectResponse);
@@ -41,11 +50,22 @@ export const ResponseTab = (props) => {
         ) : null}
       </div>
       <div className="response-status">
-        <div>Status:</div>
-        <div className="text-response-status">{`${response.status} ${response.statusText}`}</div>
+        <ResponseInfo
+          responseTitle="Status:"
+          info={`${response.status} ${response.statusText}`}
+        />
+        <ResponseInfo
+          responseTitle="Duration:"
+          info={`${response.duration} ms`}
+        />
       </div>
     </div>
   );
+};
+
+ResponseInfo.propTypes = {
+  responseTitle: propTypes.string.isRequired,
+  info: propTypes.string.isRequired,
 };
 
 ResponseTab.propTypes = {

--- a/webview/features/response/ResponseTab/styles.css
+++ b/webview/features/response/ResponseTab/styles.css
@@ -41,9 +41,10 @@
   align-items: center;
 }
 
-.text-response-status {
+.text-response-info {
   color: var(--tab-info);
   margin-left: 5px;
+  margin-right: 5px;
 }
 
 .select-res-lang {

--- a/webview/features/response/responseSlice.ts
+++ b/webview/features/response/responseSlice.ts
@@ -9,6 +9,7 @@ export interface ResponseState {
   error?: Error;
   loading?: boolean;
   headers?: { key: string; value: string }[];
+  duration?: number;
 }
 
 const initialState: ResponseState = { initial: true };

--- a/webview/redux/store.ts
+++ b/webview/redux/store.ts
@@ -6,7 +6,7 @@ import requestMethodReducer from "../features/requestMethod/requestMethodSlice";
 import requestUrlReducer from "../features/requestUrl/requestUrlSlice";
 import responseReducer from "../features/response/responseSlice";
 import codeGenOptionsReducer from "../features/codeGen/codeGenSlice";
-import requestOptionsReducer from '../features/requestOptions/requestOptionsSlice';
+import requestOptionsReducer from "../features/requestOptions/requestOptionsSlice";
 
 let preloadedState;
 if (typeof window !== "undefined") {
@@ -23,7 +23,7 @@ export const store = configureStore({
     requestUrl: requestUrlReducer,
     response: responseReducer,
     codeGenOptions: codeGenOptionsReducer,
-    requestOptions: requestOptionsReducer
+    requestOptions: requestOptionsReducer,
   },
   preloadedState,
 });


### PR DESCRIPTION
- Display the response time in milliseconds in the `ResponseTab` similarly to the Postman
- Address some linting issues

Screenshot: 

![Screenshot 2021-08-03 at 20 31 17](https://user-images.githubusercontent.com/15982721/128075533-cbdbf3cf-002d-45c7-b7fc-d7fda0833d13.png)


closes #7 